### PR TITLE
Cleanup of the graph and creation of data download script

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,6 @@ a, a:visited {
 
 #container {
   width: 100%;
-  //padding: 5px 0 10px 0;
   margin: auto;
 }
 
@@ -23,7 +22,6 @@ header {
 }
 
 #controls {
-    //padding-top: 10px;
     text-align: center;
     margin: 0 auto;
     background-color: #eee;

--- a/python/download_data.py
+++ b/python/download_data.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+#from urllib import urlencode
+#from urllib2 import urlopen
+import mechanize, cookielib
+
+import os, re, httplib
+#from bs4 import BeautifulSoup
+
+MECHANIZE_DEBUG=False
+
+url = 'http://periodicdisclosures.aec.gov.au/AnalysisParty.aspx'
+info_to_retrieve = []
+
+browser = mechanize.Browser()
+cookies = cookielib.LWPCookieJar()
+browser.set_cookiejar(cookies)
+
+#browser.set_handle_equiv(True)
+#browser.set_handle_gzip(True)
+#browser.set_handle_redirect(True)
+#browser.set_handle_referer(True)
+#browser.set_handle_robots(False)
+#browser.set_handle_refresh(mechanize._http.HTTPRefreshProcessor(), max_time=1)
+#browser.addheaders = [('User-agent', 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008071615 Fedora/3.0.1-1.fc9 Firefox/3.0.1')]
+
+if MECHANIZE_DEBUG:
+    import sys, logging
+    logger = logging.getLogger("mechanize")
+    logger.addHandler(logging.StreamHandler(sys.stdout))
+    logger.setLevel(logging.DEBUG)
+    browser.set_debug_http(True)
+    #browser.set_debug_responses(True)
+    #browser.set_debug_redirects(True)
+
+year_data = []
+parties_data = []
+
+response = browser.open(url)
+
+browser.select_form(nr=2)
+
+control = browser.form.find_control('ctl00$dropDownListPeriod')
+
+for item in control.items:
+    year_data.append({
+        'label': control.get_item_attrs(item.name)['label'],
+        'value': control.get_item_attrs(item.name)['value']
+    })
+
+
+for year in year_data:
+    browser.select_form(nr=2)
+    print "Retrieving data for " + year['label']
+    browser[control.name] = [year['value'],]
+
+    response = browser.submit()
+    response = browser.follow_link(url='AnalysisParty.aspx')
+    browser.select_form(nr=2)
+
+    parties_select = browser.form.find_control('ctl00$ContentPlaceHolderBody$dropDownListParties')
+
+    for item in parties_select.items:
+        party_name = parties_select.get_item_attrs(item.name)['label']
+        print "Retrieving data for " + party_name + " for " + year['label']
+
+        browser.select_form(nr=2)
+        browser[parties_select.name] = [parties_select.get_item_attrs(item.name)['value'],]
+        browser.submit(label='Export')
+
+        browser.select_form(nr=2)
+        browser['ctl00$ContentPlaceHolderBody$exportControl$dropDownListOptions'] = ['csv',]
+        browser.submit(label='Continue')
+
+        csv_data = browser.response()
+
+        filename = csv_data.info()['content-disposition'].split(';')[1].split('=')[1]
+        path = "data/%s" % (year['label'])
+
+        if not os.path.exists(path):
+            os.makedirs(path)
+
+        filename = "%s/%s" % (path, filename)
+
+        f = open(filename, 'w')
+        try:
+            f.write(csv_data.read())
+        except httplib.IncompleteRead as e:
+            f.write(e.partial)
+
+        f.close()
+        
+        browser.back()
+
+
+
+    


### PR DESCRIPTION
Two updates here.

One of them adds a script to download ALL data from the AEC website.

The second cleans up the force directed graph:
- stops the overlap (may still require a little tuning)
- links are drawn during transition from the two different types of graph
- when alpha is low enough in the force directed mode, the force simulation is stopped.  This was already happening in the radial mode, but not the force directed mode
- when resizing the browser, the force direction simulation starts again to reposition some nodes due to the resizing

A few CSS styles have been tidied up as well.