### PR TITLE
Display a dismissable 'use larger device' recommendation to mobile users

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -169,3 +169,16 @@ input[type=range][orient=vertical]
 .node {
   cursor: pointer;
 }
+
+.mobile-intro {
+    display: none;
+}
+
+@media ( max-width: 767px ) {
+    .navbar-fixed-top {
+        padding: 1rem;
+    }
+    .mobile-intro {
+        display: block;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -79,6 +79,11 @@
       <button type="button" class="btn btn-primary navbar-btn" data-toggle="modal" data-target="#getting-started-modal" 
         onclick="logClick('button', 'getting started')">Getting Started</button>
       <p class="navbar-text navbar-right">Data obtained from <a class="navbar-link" href="http://periodicdisclosures.aec.gov.au/">AEC</a>.</p>
+
+      <div class="mobile-intro alert alert-warning alert-dismissible" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <p><strong>Sorry!</strong> We're working on making the site available on mobile, until then, please browse the site on a larger device.</p>
+      </div>
     </div>
 
     <div class="modal fade" id="loading-modal">


### PR DESCRIPTION
This dismissable alert is visible until 767px (768 is a common tablet size, and the site is usable there).

![australian political donations visualiser 2016-05-29 18-06-32](https://cloud.githubusercontent.com/assets/218044/15632045/03e7aaac-25c9-11e6-868c-ebf816325aea.png)
