### PR TITLE
improved mobile support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -244,6 +244,9 @@ input[type=range][orient=vertical]
     .mobile-intro {
         display: block;
     }
+    .mobile-layout-block {
+        display: block;
+    }
 }
 
 /* force show scrollbars on mac
@@ -256,4 +259,16 @@ from http://stackoverflow.com/questions/7492062/css-overflow-scroll-always-show-
     border-radius: 4px;
     background-color: rgba(0,0,0,.5);
     -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+}
+
+.aec-link {
+  float: left;
+}
+
+.share-button {
+  float: right;
+}
+
+.clear {
+  clear: both
 }

--- a/css/style.css
+++ b/css/style.css
@@ -247,6 +247,38 @@ input[type=range][orient=vertical]
     .mobile-layout-block {
         display: block;
     }
+    .navbar-right {
+        display: inline-block;
+    }
+}
+
+@media (max-width: 320px) {
+    #info-toggle {
+        left: -45px;
+    }
+    #filter-toggle {
+        right: -45px;
+    }
+    .offcanvas {
+        width: 270px; /* works down to 320px wide iPhone 4 */
+    }
+    .filter-panel {
+        transform: translateX(-270px);
+    }
+    .info-panel {
+        transform: translateX(270px);
+    }
+        #info-panel {
+            padding-left: 5px;
+            padding-right: 5px;
+        }
+        #info-panel svg {
+            position: relative;
+            left: -10px;
+        }
+    .hover-info {
+        display: none; /* on small screens we pull up node info sidebar instead */
+    }
 }
 
 /* force show scrollbars on mac

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
             <span class="mobile-layout-block">
                 <div class="navbar-text navbar-right">
-                    Data obtained from the <a class="navbar-link" href="http://periodicdisclosures.aec.gov.au/" target="_blank">AEC</a>
+                    Data from the <a class="navbar-link" href="http://periodicdisclosures.aec.gov.au/" target="_blank">AEC</a>
                 </div>
 
                 <!-- share buttons -->

--- a/index.html
+++ b/index.html
@@ -51,7 +51,14 @@
     <!-- end code for social share buttons -->
 
     <div class="navbar navbar-default navbar-fixed-top">
-        <h4 class="navbar-text">Australian Political Donations</h4>
+        <h4 class="navbar-text">
+          <div id="dialog-button-toggle" data-toggle="collapse" href="#dialog-buttons">
+            Australian Political Donations
+            <div id="chevron" class="visible-xs-block pull-right indicator glyphicon glyphicon-chevron-down" />
+          </div>
+        </h4>
+
+    <div id="dialog-buttons" class="panel-collapse collapse in">
 
         <button type="button" class="btn btn-primary navbar-btn" data-toggle="modal" data-target="#about-modal"
         onclick="logClick('button', 'about')">About</button>
@@ -60,17 +67,22 @@
         onclick="logClick('button', 'getting started')">Getting Started</button>
         <button class="btn btn-success js-handleStartTour">Start Tour</button>
 
-        <div class="navbar-text navbar-right">
-            Data obtained from the <a class="navbar-link" href="http://periodicdisclosures.aec.gov.au/" target="_blank">AEC</a>
-        </div>
-        <!-- share buttons -->
-        <div class="navbar-text navbar-right"><a href="https://twitter.com/share" class="twitter-share-button" data-hashtags="politicaldonationsau">Tweet</a></div> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-        <div class="fb-share-button navbar-text navbar-right" data-href="http://www.politicaldonations.info/au" data-layout="button" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.politicaldonations.info%2Fau%2F&amp;src=sdkpreparse">Share</a></div>
+        <span class="mobile-layout-block">
+            <div class="navbar-text navbar-right">
+                Data obtained from the <a class="navbar-link" href="http://periodicdisclosures.aec.gov.au/" target="_blank">AEC</a>
+                </div>
 
-      <div class="mobile-intro alert alert-warning alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <p><strong>Sorry!</strong> We're working on making the site available on mobile, until then, please browse the site on a larger device.</p>
-      </div>
+                <!-- share buttons -->
+                <div class="navbar-text navbar-right share-button"><a href="https://twitter.com/share" class="twitter-share-button" data-hashtags="politicaldonationsau">Tweet</a></div>
+                <div class="fb-share-button navbar-text navbar-right share-button" data-href="http://au.politicaldonations.info/au" data-layout="button" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fau.politicaldonations.info%2Fau%2F&amp;src=sdkpreparse">Share</a></div>
+                <div class="clear"></div>
+            </span>
+
+            <div id="mobile-warning" class="mobile-intro alert alert-warning alert-dismissible" role="alert">
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              <p><strong>Sorry!</strong> We're working on making the site available on mobile, until then, please browse the site on a larger device.</p>
+            </div>
+        </div>
     </div>
 
     <div class="body-content container-fluid">

--- a/index.html
+++ b/index.html
@@ -52,24 +52,22 @@
 
     <div class="navbar navbar-default navbar-fixed-top">
         <h4 class="navbar-text">
-          <div id="dialog-button-toggle" data-toggle="collapse" href="#dialog-buttons">
-            Australian Political Donations
-            <div id="chevron" class="visible-xs-block pull-right indicator glyphicon glyphicon-chevron-down" />
-          </div>
+            <div id="dialog-button-toggle" data-toggle="collapse" href="#dialog-buttons">
+                Australian Political Donations
+                <div id="chevron" class="visible-xs-block pull-right indicator glyphicon glyphicon-chevron-down" />
+            </div>
         </h4>
 
-    <div id="dialog-buttons" class="panel-collapse collapse in">
+        <div id="dialog-buttons" class="panel-collapse collapse in">
+            <button type="button" class="btn btn-primary navbar-btn" data-toggle="modal" data-target="#about-modal"
+            onclick="logClick('button', 'about')">About</button>
+            <button type="button" class="btn btn-primary navbar-btn" data-toggle="modal" data-target="#getting-started-modal"
+            onclick="logClick('button', 'getting started')">Getting Started</button>
+            <button class="btn btn-success js-handleStartTour">Start Tour</button>
 
-        <button type="button" class="btn btn-primary navbar-btn" data-toggle="modal" data-target="#about-modal"
-        onclick="logClick('button', 'about')">About</button>
-
-        <button type="button" class="btn btn-primary navbar-btn" data-toggle="modal" data-target="#getting-started-modal"
-        onclick="logClick('button', 'getting started')">Getting Started</button>
-        <button class="btn btn-success js-handleStartTour">Start Tour</button>
-
-        <span class="mobile-layout-block">
-            <div class="navbar-text navbar-right">
-                Data obtained from the <a class="navbar-link" href="http://periodicdisclosures.aec.gov.au/" target="_blank">AEC</a>
+            <span class="mobile-layout-block">
+                <div class="navbar-text navbar-right">
+                    Data obtained from the <a class="navbar-link" href="http://periodicdisclosures.aec.gov.au/" target="_blank">AEC</a>
                 </div>
 
                 <!-- share buttons -->
@@ -79,8 +77,8 @@
             </span>
 
             <div id="mobile-warning" class="mobile-intro alert alert-warning alert-dismissible" role="alert">
-              <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-              <p><strong>Sorry!</strong> We're working on making the site available on mobile, until then, please browse the site on a larger device.</p>
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <p><strong>Sorry!</strong> We're working on making the site available on mobile, until then, please browse the site on a larger device.</p>
             </div>
         </div>
     </div>

--- a/js/donations-visualiser.js
+++ b/js/donations-visualiser.js
@@ -663,7 +663,7 @@ function updateInfoPanel() {
             });
     }
 
-    var margins = { top: 0, right: 0, bottom: 25, left: 50 },
+    var margins = { top: 0, right: 5, bottom: 25, left: extremelyNarrowClient ? 40 : 50 },
         chartWidth = 270 - margins.left - margins.right,
         chartHeight = 120 - margins.top - margins.bottom,
         x = d3.scale.ordinal().domain(d3.range(years[0], years[1] +1, 1)).rangeRoundBands([0, chartWidth]),

--- a/js/donations-visualiser.js
+++ b/js/donations-visualiser.js
@@ -6,13 +6,15 @@ var w = window,
     hoverInfo = d3.select(".hover-info"),
     filterPanel = d3.select('.filter-panel'),
     infoPanel = d3.select(".info-panel"),
+    filterControl = d3.select('#filter-toggle'),
+    infoControl = d3.select('#info-toggle'),
     $searchInput = $('#search');
 
 var navbarHeight,
     width,
     height,
     bounds = {},
-    containerDimensions = {};
+    containerDimensions = {},
     fireCoolingHandler = true;
 
 var party_map = {},
@@ -22,6 +24,14 @@ var party_map = {},
     clickedNode = null,
     oldYear = -1,
     data_loaded = false;
+
+var narrowClient = $(window).width() < 800,
+    extremelyNarrowClient = $(window).width() < 400,
+    isMobile = false;
+// Detect mobile - User Agent seems to be the best way to do this currently
+if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|ipad|iris|kindle|Android|Silk|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i.test(navigator.userAgent)
+    || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(navigator.userAgent.substr(0,4))) isMobile = true;
+
 
 // http://bootstraptour.com/api/
 var tour = new Tour({
@@ -205,12 +215,38 @@ function resizeWindow() {
     if (data_loaded) force.start();
 }
 
+function readjustCanvas() {
+      // Need to readjust top navbar padding hack
+      setLayoutSizes();
+      resizeWindow();
+}
+
 d3.select(w).on("resize", resizeWindow);
+
+// ============================================================
+// Set up for a mobile or tablet
+// ============================================================
+
+// Will use pinch zoom - therefore no need to display zoom controls
+if (isMobile) {
+   d3.select("#zoom-controls").classed('hidden', true);
+}
 
 
 // ============================================================
 // Handle offcanvas elements
 // ============================================================
+
+function toggleChevron(e) {
+    $('#chevron').toggleClass('glyphicon-chevron-down glyphicon-chevron-up');
+    readjustCanvas();
+}
+
+$('#dialog-buttons').on('hidden.bs.collapse', toggleChevron);
+$('#dialog-buttons').on('shown.bs.collapse', toggleChevron);
+
+$('#mobile-warning').on('closed.bs.alert', readjustCanvas);
+
 
 var filterPanelOpen = false;
 
@@ -218,6 +254,16 @@ function toggleInfoPanel(event, state) {
     if (typeof state !== 'undefined') infoPanelOpen = state;
     else infoPanelOpen = !infoPanelOpen;
     infoPanel.classed('open', infoPanelOpen);
+
+    // if on extremely narrow client, hide info button
+    if (extremelyNarrowClient) {
+      filterControl.classed('hidden', infoPanelOpen);
+    }
+    // if on narrow client, make sure info panel gets hidden
+    if (narrowClient && infoPanelOpen) {
+      filterPanel.classed('open', false);
+      filterPanelOpen = false;
+    }
 }
 $('#info-toggle').on('click', toggleInfoPanel);
 
@@ -228,6 +274,16 @@ function toggleFilterPanel(event, state) {
     if (typeof state !== 'undefined') filterPanelOpen = state;
     else filterPanelOpen = !filterPanelOpen;
     filterPanel.classed('open', filterPanelOpen);
+
+    // if on extremely narrow client, hide info button
+    if (extremelyNarrowClient) {
+      infoControl.classed('hidden', filterPanelOpen);
+    }
+    // if on narrow client, make sure info panel gets hidden
+    if (narrowClient && filterPanelOpen) {
+      infoPanel.classed('open', false);
+      infoPanelOpen = false;
+    }
 }
 $('#filter-toggle').on('click', toggleFilterPanel);
 
@@ -331,7 +387,7 @@ function coolHandler() {
         zoomToFit();
 
         window.setTimeout(function() {
-            toggleFilterPanel(null, true);
+            if (!isMobile) toggleFilterPanel(null, true);
             if (firstLoad()) {
                 tour.init();
                 tour.restart();


### PR DESCRIPTION

* try to keep 'data from aec' and share buttons on same line

* removing 'obtained': same meaning but fits better on mobile

* improve info panel chart for mobile
  - on very narrow screens, tighten margins slightly

* tighten info & filter pane for mobile
  - 270 vs 300px wide panels
  - slightly less margins/padding

* don't show hover info on very small screens like iPhone 4 or 5
  - on small screens we pull up node info sidebar instead

- relates to river-jade/donations-visualiser#27